### PR TITLE
Added firms with a Brisbane presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ A list of Information Security firms operating in Australia, and where student i
 | Shearwater    | https://shearwater.com.au      | Melbourne, Canberra, Sydney, Brisbane |
 | NCC Group     | https://www.nccgroup.trust/au/ | Australia wide | Student intake program in Sydney |
 | Privasec      | https://privasec.com/          |    | |
+| Alcorn Group  | https://alcorngroup.com        | Brisbane, Sydney  | |
+| Content Security  | https://contentsecurity.com.au  | Brisbane, Melbourne, Sydney | |
+| CoreSec | https://coresec.com.au | Brisbane, Melbourne, Sydney | |
+| Hivint        | https://hivint.com             | Brisbane, Melbourne, Perth, Sydney | |
+| Intalock | https://intalock.com.au | Brisbane, Sydney | |
+| Trusted Security Services     | https://tsscyber.com.au/  | Brisbane, Canberra, Sydney, Melbourne | |


### PR DESCRIPTION
Thanks to Google, I've found and added some firms with a Brisbane presence. Hope this meets the contribution requirements - please push back if not, and I'll update.

- Alcorn Group
- Content Security
- CoreSec
- Hivint
- Intalock
- Trusted Security Services

I believe TSS are currently hiring a Junior Penetration Tester, can't find it on their website but there was an announcement made at the recent SecTalks Brisbane event in September.